### PR TITLE
transform and replace jars in mini image

### DIFF
--- a/dev/transformer/build.gradle
+++ b/dev/transformer/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-  implementation 'biz.aQute.bnd:biz.aQute.bndlib:4.3.1'
-  implementation 'commons-cli:commons-cli:1.4'
+  compile 'biz.aQute.bnd:biz.aQute.bndlib:4.3.1'
+  compile 'commons-cli:commons-cli:1.4'
 
-  runtimeOnly 'org.slf4j:slf4j-simple:1.7.29'
+  compile 'org.slf4j:slf4j-simple:1.7.29'
 
   testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'
   testImplementation 'org.assertj:assertj-core:3.14.0'
@@ -71,3 +71,82 @@ task downloadArchives(type: Copy) {
   into "${buildDir}/archives"
   from configurations.archive
 }
+
+// **************************** Setup **************************** //
+
+/* Add Requires jars to the Transformer.jar Manifest Classpath */
+jar {
+    manifest {
+        attributes 'Main-Class': 'com.ibm.ws.jakarta.transformer.JakartaTransformer'
+        attributes 'Class-Path': configurations.compile.collect { it.name }.join(' ')
+    }
+}
+
+task copyLibs(type: Copy) {
+    from configurations.compile
+    into 'build/libs/'
+    doLast {
+      println "Copied to build/libs"
+    }
+}
+
+// ******************** Transforming Mini Image ****************** //
+
+
+String[] bundlesToBeChanged = ["com.ibm.ws.org.apache.commons.fileupload_1.0.36.jar",
+                                 "com.ibm.ws.session_1.0.36.jar",
+                                 "com.ibm.ws.webcontainer.cors_1.0.36.jar",
+                                 "com.ibm.ws.webcontainer.servlet.3.1_1.0.36.jar",
+                                 "com.ibm.ws.webcontainer.servlet.4.0.factories_1.0.36.jar",
+                                 "com.ibm.ws.webcontainer.servlet.4.0_1.0.36.jar",
+                                 "com.ibm.ws.webcontainer_1.1.36.jar",
+                                 "com.ibm.ws.webserver.plugin.runtime_1.0.36.jar"] 
+
+task transformJars() {
+    bundlesToBeChanged.each { file ->
+        doLast {
+            mkdir "../source.image/mini-image/wlp/lib/jakarta"
+            javaexec {
+                classpath = sourceSets.main.runtimeClasspath
+                main = "com.ibm.ws.jakarta.transformer.JakartaTransformer";
+                args = [  "-j",
+                          "../source.image/mini-image/wlp/lib/$file",
+                          "-o",
+                          "../source.image/mini-image/wlp/lib/jakarta/$file"]
+            }
+        }
+    
+    }
+}
+
+task deleteJavaxJars() {
+    doLast{
+        bundlesToBeChanged.each { file ->
+            delete {
+                delete "../source.image/mini-image/wlp/lib/$file"
+                println "wlp/libs/$file deleted"
+            }
+        }
+    }
+}
+
+task replaceJars(type:Copy){
+    from "../source.image/mini-image/wlp/lib/jakarta/"
+    into '../source.image/mini-image/wlp/lib/'
+    doLast {
+        delete {
+            delete '../source.image/mini-image/wlp/lib/jakarta'
+        }
+    }
+}
+
+task transform(){
+    doLast {
+      println "Transformation may be complete! See transformJars output for details"
+    }
+}
+
+transform.dependsOn replaceJars
+replaceJars.dependsOn deleteJavaxJars
+deleteJavaxJars.dependsOn transformJars
+transformJars.dependsOn copyLibs


### PR DESCRIPTION
use `gradle transform`

this transforms the jars, ouputs them in the jarkarta folder, deletes the servlet javax jars, moves the jarkarta jars back (rename them, too), and then deletes the jakarta folder.  

I'm thinking custom tasks are a better way to go. The current way is not very flexible, but it works for now. Once again, I'd like your input. 

It would also help to have this become a gradle multi-project. 
