### PR TITLE
Transformation of TLD content and Properties file relocation

### DIFF
--- a/transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -54,6 +54,7 @@ import org.eclipse.transformer.action.impl.RarActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
 import org.eclipse.transformer.action.impl.ServiceLoaderConfigActionImpl;
 import org.eclipse.transformer.action.impl.SignatureRuleImpl;
+import org.eclipse.transformer.action.impl.TldActionImpl;
 import org.eclipse.transformer.action.impl.WarActionImpl;
 import org.eclipse.transformer.action.impl.XmlActionImpl;
 import org.eclipse.transformer.action.impl.ZipActionImpl;
@@ -1260,7 +1261,8 @@ public class Transformer {
                     useRootAction.addUsing( ManifestActionImpl::newFeatureAction );
                 PropertiesActionImpl propertiesAction
                         = useRootAction.addUsing(PropertiesActionImpl::new);
-
+                TldActionImpl tldAction
+                        = useRootAction.addUsing(TldActionImpl::new);
                 JarActionImpl jarAction =
                     useRootAction.addUsing( JarActionImpl::new );
                 WarActionImpl warAction =
@@ -1301,6 +1303,7 @@ public class Transformer {
                 jarAction.addAction(featureAction);
                 jarAction.addAction(xmlAction);
                 jarAction.addAction(propertiesAction);
+                jarAction.addAction(tldAction);
                 jarAction.addAction(nullAction);
 
                 warAction.addAction(classAction);

--- a/transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -49,6 +49,7 @@ import org.eclipse.transformer.action.impl.JarActionImpl;
 import org.eclipse.transformer.action.impl.JavaActionImpl;
 import org.eclipse.transformer.action.impl.ManifestActionImpl;
 import org.eclipse.transformer.action.impl.NullActionImpl;
+import org.eclipse.transformer.action.impl.PropertiesActionImpl;
 import org.eclipse.transformer.action.impl.RarActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
 import org.eclipse.transformer.action.impl.ServiceLoaderConfigActionImpl;
@@ -1257,6 +1258,8 @@ public class Transformer {
                     useRootAction.addUsing( ManifestActionImpl::newManifestAction );
                 ManifestActionImpl featureAction =
                     useRootAction.addUsing( ManifestActionImpl::newFeatureAction );
+                PropertiesActionImpl propertiesAction
+                        = useRootAction.addUsing(PropertiesActionImpl::new);
 
                 JarActionImpl jarAction =
                     useRootAction.addUsing( JarActionImpl::new );
@@ -1297,6 +1300,7 @@ public class Transformer {
                 jarAction.addAction(manifestAction);
                 jarAction.addAction(featureAction);
                 jarAction.addAction(xmlAction);
+                jarAction.addAction(propertiesAction);
                 jarAction.addAction(nullAction);
 
                 warAction.addAction(classAction);

--- a/transformer/src/main/java/org/eclipse/transformer/action/ActionType.java
+++ b/transformer/src/main/java/org/eclipse/transformer/action/ActionType.java
@@ -18,10 +18,10 @@ public enum ActionType {
 	MANIFEST, FEATURE,
 	SERVICE_LOADER_CONFIG,
 	XML,
-
-	ZIP, JAR, WAR, RAR, EAR,
+   	ZIP, JAR, WAR, RAR, EAR,
 	JAVA,
-	DIRECTORY;
+        DIRECTORY,
+        PROPERTIES;
 
 	public boolean matches(String tag) {
 		return name().toLowerCase().startsWith(tag);

--- a/transformer/src/main/java/org/eclipse/transformer/action/ActionType.java
+++ b/transformer/src/main/java/org/eclipse/transformer/action/ActionType.java
@@ -21,7 +21,8 @@ public enum ActionType {
    	ZIP, JAR, WAR, RAR, EAR,
 	JAVA,
         DIRECTORY,
-        PROPERTIES;
+        PROPERTIES,
+        TLD;
 
 	public boolean matches(String tag) {
 		return name().toLowerCase().startsWith(tag);

--- a/transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
+++ b/transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
@@ -1,0 +1,54 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.eclipse.transformer.action.impl;
+
+import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionType;
+import org.eclipse.transformer.util.ByteData;
+import org.slf4j.Logger;
+/**
+ *
+ * @author jdenise
+ */
+public class PropertiesActionImpl extends ActionImpl {
+
+    public PropertiesActionImpl(
+            Logger logger, boolean isTerse, boolean isVerbose,
+            InputBufferImpl buffer,
+            SelectionRuleImpl selectionRule,
+            SignatureRuleImpl signatureRule) {
+
+        super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+    }
+
+    @Override
+    public String getAcceptExtension() {
+        return ".properties";
+    }
+
+    @Override
+    protected ByteData apply(String inputName, byte[] inputBytes, int inputLength) throws TransformException {
+
+        String outputName = transformBinaryType(inputName);
+        if (outputName != null) {
+            verbose("Properties file %s, relocated to %s", inputName, outputName);
+            setResourceNames(inputName, outputName);
+            return new ByteData(outputName, inputBytes, 0, inputLength);
+        } else {
+            setResourceNames(inputName, inputName);
+            return new ByteData(inputName, inputBytes, 0, inputLength);
+        }
+    }
+
+    public String getName() {
+        return "Properties file relocate";
+    }
+
+    public ActionType getActionType() {
+        return ActionType.PROPERTIES;
+    }
+
+}

--- a/transformer/src/main/java/org/eclipse/transformer/action/impl/TldActionImpl.java
+++ b/transformer/src/main/java/org/eclipse/transformer/action/impl/TldActionImpl.java
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package org.eclipse.transformer.action.impl;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionType;
+import org.eclipse.transformer.util.ByteData;
+import org.slf4j.Logger;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class TldActionImpl extends XmlActionImpl {
+
+	public TldActionImpl(
+		Logger logger, boolean isTerse, boolean isVerbose,
+		InputBufferImpl buffer,
+		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
+
+		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+	}
+
+	//
+
+    @Override
+	public String getName() {
+            return "TLD Action";
+	}
+
+	@Override
+	public ActionType getActionType() {
+            return ActionType.TLD;
+	}
+
+	@Override
+	public String getAcceptExtension() {
+            return ".tld";
+    }
+}

--- a/transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
+++ b/transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
@@ -1,0 +1,109 @@
+/** ******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ******************************************************************************* */
+package transformer.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.impl.PropertiesActionImpl;
+import org.eclipse.transformer.action.impl.SelectionRuleImpl;
+import org.eclipse.transformer.action.impl.SignatureRuleImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import transformer.test.util.CaptureLoggerImpl;
+
+public class TestTransformPropertiesFile extends CaptureTest {
+
+    public SelectionRuleImpl createSelectionRule(
+            CaptureLoggerImpl useLogger,
+            Set<String> useIncludes,
+            Set<String> useExcludes) {
+
+        return new SelectionRuleImpl(useLogger, useIncludes, useExcludes);
+    }
+
+    public SignatureRuleImpl createSignatureRule(
+            CaptureLoggerImpl useLogger,
+            Map<String, String> packageRename) {
+
+        return new SignatureRuleImpl(
+                useLogger,
+                packageRename, null,
+                null,
+                null,
+                null);
+    }
+    
+    public static final String JAKARTA_SERVLET = "jakarta.servlet";
+
+    public static final String JAVAX_SERVLET = "javax.servlet";
+
+    public static final String JAVAX_PATH = "javax/servlet/Bundle.properties";
+
+    public static final String JAKARTA_PATH = "jakarta/servlet/Bundle.properties";
+
+    protected Set<String> includes;
+
+    public Set<String> getIncludes() {
+        if (includes == null) {
+            includes = new HashSet<String>();
+            includes.add(JAVAX_PATH);
+        }
+
+        return includes;
+    }
+
+    public Set<String> getExcludes() {
+        return Collections.emptySet();
+    }
+
+    protected Map<String, String> packageRenames;
+
+	public Map<String, String> getPackageRenames() {
+		if ( packageRenames == null ) {
+			packageRenames = new HashMap<String, String>();
+			packageRenames.put(JAVAX_SERVLET, JAKARTA_SERVLET);
+		}
+		return packageRenames;
+	}
+
+    public PropertiesActionImpl jakartaPropertiesAction;
+
+    public PropertiesActionImpl getJakartaPropertiesAction() {
+        if (jakartaPropertiesAction == null) {
+            CaptureLoggerImpl useLogger = getCaptureLogger();
+
+            jakartaPropertiesAction = new PropertiesActionImpl(
+                    useLogger, false, false,
+                    createBuffer(),
+                    createSelectionRule(useLogger, getIncludes(), getExcludes()),
+                    createSignatureRule(useLogger, getPackageRenames()));
+        }
+        return jakartaPropertiesAction;
+    }
+
+    @Test
+    public void testJakartaTransform() throws IOException, TransformException {
+        PropertiesActionImpl propsAction = getJakartaPropertiesAction();
+
+        byte[] content = {};
+        propsAction.apply(JAVAX_PATH, new ByteArrayInputStream(content));
+        Assertions.assertTrue(JAKARTA_PATH.equals(propsAction.getLastActiveChanges().getOutputResourceName()));
+    }
+
+}

--- a/transformer/src/test/java/transformer/test/TestTransformTld.java
+++ b/transformer/src/test/java/transformer/test/TestTransformTld.java
@@ -1,0 +1,138 @@
+/** ******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ******************************************************************************* */
+package transformer.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.impl.SelectionRuleImpl;
+import org.eclipse.transformer.action.impl.TldActionImpl;
+import org.eclipse.transformer.action.impl.SignatureRuleImpl;
+import org.eclipse.transformer.util.InputStreamData;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import transformer.test.util.CaptureLoggerImpl;
+
+public class TestTransformTld extends CaptureTest {
+
+    public SelectionRuleImpl createSelectionRule(
+            CaptureLoggerImpl useLogger,
+            Set<String> useIncludes,
+            Set<String> useExcludes) {
+
+        return new SelectionRuleImpl(useLogger, useIncludes, useExcludes);
+    }
+
+    public SignatureRuleImpl createSignatureRule(
+            CaptureLoggerImpl useLogger,
+            Map<String, Map<String, String>> masterXmlUpdates) {
+
+        return new SignatureRuleImpl(
+                useLogger,
+                null, null,
+                null,
+                masterXmlUpdates,
+                null);
+    }
+
+    //
+    public static final String TEST_DATA_PATH = "transformer/test/data/tld";
+
+    public static final String JAVAX_TLD_PATH = TEST_DATA_PATH + "/" + "META-INF/test-javax.tld";
+
+    public static final String JAKARTA_SERVLET = "jakarta.servlet";
+
+    public static final String JAVAX_SERVLET = "javax.servlet";
+
+    public static final String ALL_TLD = "*.tld";
+
+    protected Set<String> includes;
+
+    public Set<String> getIncludes() {
+        if (includes == null) {
+            includes = new HashSet<String>();
+            includes.add(JAVAX_TLD_PATH);
+        }
+
+        return includes;
+    }
+
+    public Set<String> getExcludes() {
+        return Collections.emptySet();
+    }
+
+    public Map<String, Map<String, String>> masterXmlUpdates;
+
+    public Map<String, Map<String, String>> getMasterXmlUpdates() {
+        if (masterXmlUpdates == null) {
+            Map<String, Map<String, String>> useTldUpdates = new HashMap<String, Map<String, String>>(2);
+
+            Map<String, String> tldUpdates = new HashMap<String, String>(1);
+            tldUpdates.put(JAVAX_SERVLET, JAKARTA_SERVLET);
+            useTldUpdates.put(ALL_TLD, tldUpdates);
+            masterXmlUpdates = useTldUpdates;
+        }
+
+        return masterXmlUpdates;
+    }
+
+    public TldActionImpl jakartaServiceAction;
+
+    public TldActionImpl getJakartaTldAction() {
+        if (jakartaServiceAction == null) {
+            CaptureLoggerImpl useLogger = getCaptureLogger();
+
+            jakartaServiceAction = new TldActionImpl(
+                    useLogger, false, false,
+                    createBuffer(),
+                    createSelectionRule(useLogger, getIncludes(), getExcludes()),
+                    createSignatureRule(useLogger, getMasterXmlUpdates()));
+        }
+        return jakartaServiceAction;
+    }
+
+    @Test
+    public void testJakartaTransform() throws IOException, TransformException {
+        TldActionImpl tldAction = getJakartaTldAction();
+
+        verifyTransform(
+                tldAction,
+                JAVAX_TLD_PATH);
+    }
+
+    protected void verifyTransform(
+            TldActionImpl action,
+            String inputName) throws IOException, TransformException {
+
+        InputStream inputStream = TestUtils.getResourceStream(inputName);
+
+        InputStreamData transformedData;
+        try {
+            transformedData = action.apply(inputName, inputStream);
+        } finally {
+            inputStream.close();
+        }
+
+        List<String> transformedLines = TestUtils.loadLines(transformedData.stream);
+        for(String l : transformedLines) {
+            Assertions.assertFalse(l.contains(JAVAX_SERVLET));
+        }
+    }
+
+}

--- a/transformer/src/test/resources/transformer/test/data/tld/META-INF/test-javax.tld
+++ b/transformer/src/test/resources/transformer/test/data/tld/META-INF/test-javax.tld
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
+        version="2.0">
+    <description>
+        Test
+    </description>
+    <display-name>TestTL</display-name>
+    <tlib-version>1.1</tlib-version>
+    <short-name>testTL</short-name>
+
+    <validator>
+        <validator-class>
+            javax.servlet.jsp.jstl.tlv.PermittedTaglibsTLV
+        </validator-class>
+    </validator>
+</taglib>


### PR DESCRIPTION
2 commits to fix the 2 issues:
* https://github.com/tbitonti/jakartaee-prototype/issues/121
* https://github.com/tbitonti/jakartaee-prototype/issues/125

* The TLD action is a simple extension of the XMLActionImpl. The XML master properties file needs to contain *.tld=<properties file with XML rules>
* I didn't touch at the Jakarta transformer XML default rule files.
* The Properties action relocates the file according to the package renaming rules.
* Both actions have been added to the jar container action only.
* I have been greatly inspired by the existing unit tests to add 2 new unit tests.
